### PR TITLE
add checks for endpoint/endpoints field in status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-11-04T22:37:28Z"
+  build_date: "2021-11-05T21:04:24Z"
   build_hash: 0a8fc32cdf2d33693e919e4a59da05599b9f916e
   go_version: go1.17
   version: v0.15.1
@@ -7,7 +7,7 @@ api_directory_checksum: 550c87ef2158e5b3d58bc5a8ff5d3367c192b04a
 api_version: v1alpha1
 aws_sdk_go_version: v1.40.51
 generator_config_info:
-  file_checksum: 1aa3cbb5df5c91de25b9935978e30138af9b696d
+  file_checksum: bd75f4fe50f216466e8e62e7f5c40bd1550da7e3
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -9,6 +9,11 @@ ignore:
     - CreateDomainInput.SnapshotOptions
 resources:
   Domain:
+    reconcile:
+      # Doing this because it takes a LONG time for the Domain's
+      # endpoint/endpoints field to be populated, even after the Domain's
+      # Processing field is set to False after creation...
+      requeue_on_success_seconds: 60
     exceptions:
       errors:
         404:

--- a/generator.yaml
+++ b/generator.yaml
@@ -9,6 +9,11 @@ ignore:
     - CreateDomainInput.SnapshotOptions
 resources:
   Domain:
+    reconcile:
+      # Doing this because it takes a LONG time for the Domain's
+      # endpoint/endpoints field to be populated, even after the Domain's
+      # Processing field is set to False after creation...
+      requeue_on_success_seconds: 60
     exceptions:
       errors:
         404:

--- a/pkg/resource/domain/manager_factory.go
+++ b/pkg/resource/domain/manager_factory.go
@@ -82,7 +82,7 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 // RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
 // Default is false which means resource will not be requeued after success.
 func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
-	return 0
+	return 60
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -1209,8 +1209,13 @@ func (rm *resourceManager) updateConditions(
 			recoverableCondition.Message = nil
 		}
 	}
-	// Required to avoid the "declared but not used" error in the default case
-	_ = syncCondition
+	if syncCondition == nil && onSuccess {
+		syncCondition = &ackv1alpha1.Condition{
+			Type:   ackv1alpha1.ConditionTypeResourceSynced,
+			Status: corev1.ConditionTrue,
+		}
+		ko.Status.Conditions = append(ko.Status.Conditions, syncCondition)
+	}
 	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
 		return &resource{ko}, true // updated
 	}

--- a/test/e2e/domain.py
+++ b/test/e2e/domain.py
@@ -126,3 +126,19 @@ def get(domain_name):
     except c.exceptions.ResourceNotFoundException:
         return None
 
+
+# Apparently, there is an 'endpoint' and an 'endpoints' field for a domain.
+# The 'endpoint' field is filled in with a URL when the domain does *not* use
+# VPC endpoints. The 'endpoints' field is filled in with a map when the domain
+# *does* use VPC endpoints. The following two assertion functions verify this
+# "one or the other" behaviour
+def assert_endpoint(cr):
+    assert 'endpoint' in cr['status']
+    assert cr['status']['endpoint'] != ""
+    assert 'endpoints' not in cr['status'] or len(cr['status']['endpoints']) == 0
+
+
+def assert_endpoints(cr):
+    assert 'endpoint' not in cr['status'] or cr['status']['endpoint'] == ""
+    assert 'endpoints' in cr['status']
+    assert len(cr['status']['endpoints']) > 0


### PR DESCRIPTION
The endpoint and endpoints field in the Domain.Status struct are filled
in when the domain's endpoint URL or URLs (if VPC endpoints) are
established. Adds an e2e test to verify these fields on the Status
struct are indeed populated, which after adding
requeue_on_success_seconds to the generator.yaml file, is indeed true.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
