### PR TITLE
replace plaintext password with secret ref

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-11-05T21:04:24Z"
-  build_hash: 0a8fc32cdf2d33693e919e4a59da05599b9f916e
+  build_date: "2021-12-08T14:01:10Z"
+  build_hash: 5ffa7aecf6b688da8c06f91bdc7b342ea2848c3f
   go_version: go1.17
-  version: v0.15.1
-api_directory_checksum: 550c87ef2158e5b3d58bc5a8ff5d3367c192b04a
+  version: v0.15.2
+api_directory_checksum: 8df06e8cb192495e377044abcf87854cdb929eed
 api_version: v1alpha1
 aws_sdk_go_version: v1.40.51
 generator_config_info:
-  file_checksum: bd75f4fe50f216466e8e62e7f5c40bd1550da7e3
+  file_checksum: 387dff40ea37afcdbb465ca305c08d320e2558f4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -29,3 +29,6 @@ resources:
         template_path: hooks/domain/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/domain/sdk_delete_pre_build_request.go.tpl
+    fields:
+      AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword:
+        is_secret: true

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -377,9 +377,9 @@ type MasterUserOptions struct {
 	// The Amazon Resource Name (ARN) of the domain. See Identifiers for IAM Entities
 	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/index.html) in Using AWS
 	// Identity and Access Management for more information.
-	MasterUserARN      *string `json:"masterUserARN,omitempty"`
-	MasterUserName     *string `json:"masterUserName,omitempty"`
-	MasterUserPassword *string `json:"masterUserPassword,omitempty"`
+	MasterUserARN      *string                         `json:"masterUserARN,omitempty"`
+	MasterUserName     *string                         `json:"masterUserName,omitempty"`
+	MasterUserPassword *ackv1alpha1.SecretKeyReference `json:"masterUserPassword,omitempty"`
 }
 
 // The node-to-node encryption options.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1277,7 +1277,7 @@ func (in *MasterUserOptions) DeepCopyInto(out *MasterUserOptions) {
 	}
 	if in.MasterUserPassword != nil {
 		in, out := &in.MasterUserPassword, &out.MasterUserPassword
-		*out = new(string)
+		*out = new(corev1alpha1.SecretKeyReference)
 		**out = **in
 	}
 }

--- a/config/crd/bases/opensearchservice.services.k8s.aws_domains.yaml
+++ b/config/crd/bases/opensearchservice.services.k8s.aws_domains.yaml
@@ -66,7 +66,23 @@ spec:
                       masterUserName:
                         type: string
                       masterUserPassword:
-                        type: string
+                        description: SecretKeyReference combines a k8s corev1.SecretReference
+                          with a specific key within the referred-to Secret
+                        properties:
+                          key:
+                            description: Key is the key within the secret
+                            type: string
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        required:
+                        - key
+                        type: object
                     type: object
                   sAMLOptions:
                     description: The SAML application configuration for the domain.

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -23,6 +23,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - opensearchservice.services.k8s.aws
   resources:
   - domains

--- a/generator.yaml
+++ b/generator.yaml
@@ -29,3 +29,6 @@ resources:
         template_path: hooks/domain/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/domain/sdk_delete_pre_build_request.go.tpl
+    fields:
+      AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword:
+        is_secret: true

--- a/helm/crds/opensearchservice.services.k8s.aws_domains.yaml
+++ b/helm/crds/opensearchservice.services.k8s.aws_domains.yaml
@@ -66,7 +66,23 @@ spec:
                       masterUserName:
                         type: string
                       masterUserPassword:
-                        type: string
+                        description: SecretKeyReference combines a k8s corev1.SecretReference
+                          with a specific key within the referred-to Secret
+                        properties:
+                          key:
+                            description: Key is the key within the secret
+                            type: string
+                          name:
+                            description: Name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        required:
+                        - key
+                        type: object
                     type: object
                   sAMLOptions:
                     description: The SAML application configuration for the domain.

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -29,6 +29,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - opensearchservice.services.k8s.aws
   resources:
   - domains

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -17,6 +17,7 @@ package domain
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -834,7 +836,13 @@ func (rm *resourceManager) newCreateRequestPayload(
 				f2f2.SetMasterUserName(*r.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName)
 			}
 			if r.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword != nil {
-				f2f2.SetMasterUserPassword(*r.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword)
+				tmpSecret, err := rm.rr.SecretValueFromReference(ctx, r.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword)
+				if err != nil {
+					return nil, err
+				}
+				if tmpSecret != "" {
+					f2f2.SetMasterUserPassword(tmpSecret)
+				}
 			}
 			f2.SetMasterUserOptions(f2f2)
 		}

--- a/pkg/resource/registry.go
+++ b/pkg/resource/registry.go
@@ -24,6 +24,7 @@ import (
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 var (
 	reg = ackrt.NewRegistry()

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -19,11 +19,13 @@ from acktest.bootstrapping import Resources
 from acktest.bootstrapping.vpc import VPC
 from acktest.bootstrapping.iam import ServiceLinkedRole
 from e2e import bootstrap_directory
+from e2e import secret
 
 @dataclass
 class BootstrapResources(Resources):
     VPC: VPC
     SLR: ServiceLinkedRole
+    MasterUserPasswordSecret: secret.Secret
 
 _bootstrap_resources = None
 

--- a/test/e2e/resources/domain_es7.9.yaml
+++ b/test/e2e/resources/domain_es7.9.yaml
@@ -11,3 +11,21 @@ spec:
     ebsEnabled: true
     volumeSize: 10
     volumeType: gp2
+  # encryptionAtRestOptions.enabled, domainEndpointOptions.enforceHTTPS
+  # nodeToNodeEncryptionOptions.enabled need to be set in order to use
+  # advancedSecurityOptions...
+  domainEndpointOptions:
+    enforceHTTPS: true
+  encryptionAtRestOptions:
+    enabled: true
+  nodeToNodeEncryptionOptions:
+    enabled: true
+  advancedSecurityOptions:
+    enabled: true
+    internalUserDatabaseEnabled: true
+    masterUserOptions:
+      masterUserName: admin
+      masterUserPassword:
+        namespace: $MASTER_USER_PASS_SECRET_NAMESPACE
+        name: $MASTER_USER_PASS_SECRET_NAME
+        key: $MASTER_USER_PASS_SECRET_KEY

--- a/test/e2e/resources/domain_es_xdym_multi_az7.9.yaml
+++ b/test/e2e/resources/domain_es_xdym_multi_az7.9.yaml
@@ -16,3 +16,21 @@ spec:
     ebsEnabled: true
     volumeSize: 10
     volumeType: gp2
+  # encryptionAtRestOptions.enabled, domainEndpointOptions.enforceHTTPS
+  # nodeToNodeEncryptionOptions.enabled need to be set in order to use
+  # advancedSecurityOptions...
+  domainEndpointOptions:
+    enforceHTTPS: true
+  encryptionAtRestOptions:
+    enabled: true
+  nodeToNodeEncryptionOptions:
+    enabled: true
+  advancedSecurityOptions:
+    enabled: true
+    internalUserDatabaseEnabled: true
+    masterUserOptions:
+      masterUserName: admin
+      masterUserPassword:
+        namespace: $MASTER_USER_PASS_SECRET_NAMESPACE
+        name: $MASTER_USER_PASS_SECRET_NAME
+        key: $MASTER_USER_PASS_SECRET_KEY

--- a/test/e2e/resources/domain_es_xdym_multi_az_vpc7.9.yaml
+++ b/test/e2e/resources/domain_es_xdym_multi_az_vpc7.9.yaml
@@ -18,3 +18,21 @@ spec:
     ebsEnabled: true
     volumeSize: 10
     volumeType: gp2
+  # encryptionAtRestOptions.enabled, domainEndpointOptions.enforceHTTPS
+  # nodeToNodeEncryptionOptions.enabled need to be set in order to use
+  # advancedSecurityOptions...
+  domainEndpointOptions:
+    enforceHTTPS: true
+  encryptionAtRestOptions:
+    enabled: true
+  nodeToNodeEncryptionOptions:
+    enabled: true
+  advancedSecurityOptions:
+    enabled: true
+    internalUserDatabaseEnabled: true
+    masterUserOptions:
+      masterUserName: admin
+      masterUserPassword:
+        namespace: $MASTER_USER_PASS_SECRET_NAMESPACE
+        name: $MASTER_USER_PASS_SECRET_NAME
+        key: $MASTER_USER_PASS_SECRET_KEY

--- a/test/e2e/secret.py
+++ b/test/e2e/secret.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Fixtures common to all RDS controller tests"""
+
+import dataclasses
+
+from acktest.k8s import resource as k8s
+
+import logging
+
+from dataclasses import dataclass, field
+
+from acktest import bootstrapping
+
+
+@dataclasses.dataclass
+class Secret(bootstrapping.Bootstrappable):
+    ns: str
+    name: str
+    key: str
+    val: str
+
+    def bootstrap(self):
+        """Ensures a Kubernetes secret with the specified ns/name/key exists
+        """
+        k8s.create_opaque_secret(self.ns, self.name, self.key, self.val)
+
+    def cleanup(self):
+        """Ensures the Kubernetes secret does not exist
+        """
+        k8s.delete_secret(self.ns, self.name)

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -23,6 +23,8 @@ from e2e.bootstrap_resources import (
     VPC,
     ServiceLinkedRole
 )
+from e2e import secret
+
 
 def service_bootstrap() -> Resources:
     logging.getLogger().setLevel(logging.INFO)
@@ -33,7 +35,13 @@ def service_bootstrap() -> Resources:
             aws_service_name="opensearchservice.amazonaws.com",
             default_name="AWSServiceRoleForAmazonOpenSearchService",
             description="An SLR to allow Amazon OpenSearch Service to work within a private VPC"
-        )
+        ),
+        MasterUserPasswordSecret=secret.Secret(
+            ns="default",
+            name="passwords",
+            key="master_user_pass",
+            val="Secretpass123456!",
+        ),
     )
 
     try:

--- a/test/e2e/tests/test_domain.py
+++ b/test/e2e/tests/test_domain.py
@@ -62,11 +62,15 @@ def resources():
 
 
 @pytest.fixture
-def es_7_9_domain(os_client):
+def es_7_9_domain(os_client, resources: BootstrapResources):
     resource = Domain(name="my-os-domain", data_node_count=1)
+    mup = resources.MasterUserPasswordSecret
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements["DOMAIN_NAME"] = resource.name
+    replacements["MASTER_USER_PASS_SECRET_NAMESPACE"] = mup.ns
+    replacements["MASTER_USER_PASS_SECRET_NAME"] = mup.name
+    replacements["MASTER_USER_PASS_SECRET_KEY"] = mup.key
 
     resource_data = load_opensearch_resource(
         "domain_es7.9",
@@ -113,11 +117,15 @@ def es_7_9_domain(os_client):
 
 
 @pytest.fixture
-def es_2d3m_multi_az_no_vpc_7_9_domain(os_client):
+def es_2d3m_multi_az_no_vpc_7_9_domain(os_client, resources: BootstrapResources):
     resource = Domain(name="my-os-domain2",data_node_count=2,master_node_count=3,is_zone_aware=True)
+    mup = resources.MasterUserPasswordSecret
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements["DOMAIN_NAME"] = resource.name
+    replacements["MASTER_USER_PASS_SECRET_NAMESPACE"] = mup.ns
+    replacements["MASTER_USER_PASS_SECRET_NAME"] = mup.name
+    replacements["MASTER_USER_PASS_SECRET_KEY"] = mup.key
     replacements["MASTER_NODE_COUNT"] = str(resource.master_node_count)
     replacements["DATA_NODE_COUNT"] = str(resource.data_node_count)
 
@@ -165,9 +173,13 @@ def es_2d3m_multi_az_vpc_2_subnet7_9_domain(os_client, resources: BootstrapResou
         vpc_id=resources.VPC.vpc_id,
         vpc_subnets=resources.VPC.private_subnets.subnet_ids,
     )
+    mup = resources.MasterUserPasswordSecret
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements["DOMAIN_NAME"] = resource.name
+    replacements["MASTER_USER_PASS_SECRET_NAMESPACE"] = mup.ns
+    replacements["MASTER_USER_PASS_SECRET_NAME"] = mup.name
+    replacements["MASTER_USER_PASS_SECRET_KEY"] = mup.key
     replacements["MASTER_NODE_COUNT"] = str(resource.master_node_count)
     replacements["DATA_NODE_COUNT"] = str(resource.data_node_count)
     replacements["SUBNETS"] = str(resource.vpc_subnets)


### PR DESCRIPTION
Domain.spec.advancedSecurityOptions.MasterUserOptions.MasterUserPassword
field was plaintext. This PR replaces that plaintext field with a
SecretKeyReference field, allowing Kubernetes secrets to replace those
plaintext values.

Closes Issue aws-controllers-k8s/community#1088

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
