### PR TITLE
release artifacts for v0.0.3

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: opensearchservice-chart
 description: A Helm chart for the ACK service controller for Amazon OpenSearch Service (OpenSearch)
-version: v0.0.2
-appVersion: v0.0.2
+version: v0.0.3
+appVersion: v0.0.3
 home: https://github.com/aws-controllers-k8s/opensearchservice-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -75,3 +75,12 @@ spec:
           value: {{ join "," .Values.resourceTags | quote }}
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if .Values.deployment.tolerations -}}
+      tolerations: {{ toYaml .Values.deployment.tolerations | nindent 8 }}
+      {{ end -}}
+      {{ if .Values.deployment.affinity -}}
+      affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
+      {{ end -}}
+      {{ if .Values.deployment.priorityClassName -}}
+      priorityClassName: {{ .Values.deployment.priorityClassName -}}
+      {{ end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/opensearchservice-controller
-  tag: v0.0.2
+  tag: v0.0.3
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -15,9 +15,20 @@ deployment:
   annotations: {}
   labels: {}
   containerPort: 8080
+  # Which nodeSelector to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
-
+  # Which tolerations to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: {}
+  # What affinity to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  # Which priorityClassName to set?
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+  priorityClassName:
+  
 metrics:
   service:
     # Set to true to automatically create a Kubernetes Service resource for the


### PR DESCRIPTION
Support for SecretKeyReference replacement of plaintext master user
password fields.

BREAKING CHANGE: the Go type of the `Domain` CRD's
`spec.advancedSecurityOptions.masterUserOptions.masterUserPassword`
field has changed from `*string` to `*ackv1alpha1.SecretKeyReference`

Issue: aws-controllers-k8s/community#1088

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
