### PR TITLE
rename Domain.DomainName and Domain.TagList

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-02-08T20:19:28Z"
-  build_hash: edec6dad2fbd530d615d01e96f5251a806e1f36d
-  go_version: go1.17.5
+  build_date: "2022-02-15T13:29:21Z"
+  build_hash: ed9e0549897309771998419452a47e2f7f467f80
+  go_version: go1.17
   version: v0.16.5
-api_directory_checksum: 6f3ca5de4e5a1ac8cb5366ab502f7c73c8d5c88f
+api_directory_checksum: b71af3be7579dea735994a82ef7595183473598b
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 387dff40ea37afcdbb465ca305c08d320e2558f4
+  file_checksum: bd3133286f996b9a993aee42d06c278d88c24b2e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/domain.go
+++ b/apis/v1alpha1/domain.go
@@ -42,12 +42,6 @@ type DomainSpec struct {
 	CognitoOptions *CognitoOptions `json:"cognitoOptions,omitempty"`
 	// Options to specify configurations that will be applied to the domain endpoint.
 	DomainEndpointOptions *DomainEndpointOptions `json:"domainEndpointOptions,omitempty"`
-	// The name of the Amazon OpenSearch Service domain you're creating. Domain
-	// names are unique across the domains owned by an account within an AWS region.
-	// Domain names must start with a lowercase letter and can contain the following
-	// characters: a-z (lowercase), 0-9, and - (hyphen).
-	// +kubebuilder:validation:Required
-	DomainName *string `json:"domainName"`
 	// Options to enable, disable, and specify the type and size of EBS storage
 	// volumes.
 	EBSOptions *EBSOptions `json:"ebsOptions,omitempty"`
@@ -61,10 +55,16 @@ type DomainSpec struct {
 	// Map of LogType and LogPublishingOption, each containing options to publish
 	// a given type of OpenSearch log.
 	LogPublishingOptions map[string]*LogPublishingOption `json:"logPublishingOptions,omitempty"`
+	// The name of the Amazon OpenSearch Service domain you're creating. Domain
+	// names are unique across the domains owned by an account within an AWS region.
+	// Domain names must start with a lowercase letter and can contain the following
+	// characters: a-z (lowercase), 0-9, and - (hyphen).
+	// +kubebuilder:validation:Required
+	Name *string `json:"name"`
 	// Node-to-node encryption options.
 	NodeToNodeEncryptionOptions *NodeToNodeEncryptionOptions `json:"nodeToNodeEncryptionOptions,omitempty"`
 	// A list of Tag added during domain creation.
-	TagList []*Tag `json:"tagList,omitempty"`
+	Tags []*Tag `json:"tags,omitempty"`
 	// Options to specify the subnets and security groups for a VPC endpoint. For
 	// more information, see Launching your Amazon OpenSearch Service domains using
 	// a VPC (http://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc.html).

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -9,6 +9,18 @@ ignore:
     - CreateDomainInput.SnapshotOptions
 resources:
   Domain:
+    renames:
+      operations:
+        CreateDomain:
+          input_fields:
+            DomainName: Name
+            TagList: Tags
+        DeleteDomain:
+          input_fields:
+            DomainName: Name
+        DescribeDomain:
+          input_fields:
+            DomainName: Name
     reconcile:
       # Doing this because it takes a LONG time for the Domain's
       # endpoint/endpoints field to be populated, even after the Domain's

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -718,11 +718,6 @@ func (in *DomainSpec) DeepCopyInto(out *DomainSpec) {
 		*out = new(DomainEndpointOptions)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.DomainName != nil {
-		in, out := &in.DomainName, &out.DomainName
-		*out = new(string)
-		**out = **in
-	}
 	if in.EBSOptions != nil {
 		in, out := &in.EBSOptions, &out.EBSOptions
 		*out = new(EBSOptions)
@@ -753,13 +748,18 @@ func (in *DomainSpec) DeepCopyInto(out *DomainSpec) {
 			(*out)[key] = outVal
 		}
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.NodeToNodeEncryptionOptions != nil {
 		in, out := &in.NodeToNodeEncryptionOptions, &out.NodeToNodeEncryptionOptions
 		*out = new(NodeToNodeEncryptionOptions)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.TagList != nil {
-		in, out := &in.TagList, &out.TagList
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
 		*out = make([]*Tag, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {

--- a/config/crd/bases/opensearchservice.services.k8s.aws_domains.yaml
+++ b/config/crd/bases/opensearchservice.services.k8s.aws_domains.yaml
@@ -225,13 +225,6 @@ spec:
                   tlsSecurityPolicy:
                     type: string
                 type: object
-              domainName:
-                description: 'The name of the Amazon OpenSearch Service domain you''re
-                  creating. Domain names are unique across the domains owned by an
-                  account within an AWS region. Domain names must start with a lowercase
-                  letter and can contain the following characters: a-z (lowercase),
-                  0-9, and - (hyphen).'
-                type: string
               ebsOptions:
                 description: Options to enable, disable, and specify the type and
                   size of EBS storage volumes.
@@ -283,13 +276,20 @@ spec:
                 description: Map of LogType and LogPublishingOption, each containing
                   options to publish a given type of OpenSearch log.
                 type: object
+              name:
+                description: 'The name of the Amazon OpenSearch Service domain you''re
+                  creating. Domain names are unique across the domains owned by an
+                  account within an AWS region. Domain names must start with a lowercase
+                  letter and can contain the following characters: a-z (lowercase),
+                  0-9, and - (hyphen).'
+                type: string
               nodeToNodeEncryptionOptions:
                 description: Node-to-node encryption options.
                 properties:
                   enabled:
                     type: boolean
                 type: object
-              tagList:
+              tags:
                 description: A list of Tag added during domain creation.
                 items:
                   description: A key value pair for a resource tag.
@@ -321,7 +321,7 @@ spec:
                     type: array
                 type: object
             required:
-            - domainName
+            - name
             type: object
           status:
             description: DomainStatus defines the observed state of Domain

--- a/generator.yaml
+++ b/generator.yaml
@@ -9,6 +9,18 @@ ignore:
     - CreateDomainInput.SnapshotOptions
 resources:
   Domain:
+    renames:
+      operations:
+        CreateDomain:
+          input_fields:
+            DomainName: Name
+            TagList: Tags
+        DeleteDomain:
+          input_fields:
+            DomainName: Name
+        DescribeDomain:
+          input_fields:
+            DomainName: Name
     reconcile:
       # Doing this because it takes a LONG time for the Domain's
       # endpoint/endpoints field to be populated, even after the Domain's

--- a/helm/crds/opensearchservice.services.k8s.aws_domains.yaml
+++ b/helm/crds/opensearchservice.services.k8s.aws_domains.yaml
@@ -225,13 +225,6 @@ spec:
                   tlsSecurityPolicy:
                     type: string
                 type: object
-              domainName:
-                description: 'The name of the Amazon OpenSearch Service domain you''re
-                  creating. Domain names are unique across the domains owned by an
-                  account within an AWS region. Domain names must start with a lowercase
-                  letter and can contain the following characters: a-z (lowercase),
-                  0-9, and - (hyphen).'
-                type: string
               ebsOptions:
                 description: Options to enable, disable, and specify the type and
                   size of EBS storage volumes.
@@ -283,13 +276,20 @@ spec:
                 description: Map of LogType and LogPublishingOption, each containing
                   options to publish a given type of OpenSearch log.
                 type: object
+              name:
+                description: 'The name of the Amazon OpenSearch Service domain you''re
+                  creating. Domain names are unique across the domains owned by an
+                  account within an AWS region. Domain names must start with a lowercase
+                  letter and can contain the following characters: a-z (lowercase),
+                  0-9, and - (hyphen).'
+                type: string
               nodeToNodeEncryptionOptions:
                 description: Node-to-node encryption options.
                 properties:
                   enabled:
                     type: boolean
                 type: object
-              tagList:
+              tags:
                 description: A list of Tag added during domain creation.
                 items:
                   description: A key value pair for a resource tag.
@@ -321,7 +321,7 @@ spec:
                     type: array
                 type: object
             required:
-            - domainName
+            - name
             type: object
           status:
             description: DomainStatus defines the observed state of Domain

--- a/pkg/resource/domain/delta.go
+++ b/pkg/resource/domain/delta.go
@@ -336,13 +336,6 @@ func newResourceDelta(
 			}
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.DomainName, b.ko.Spec.DomainName) {
-		delta.Add("Spec.DomainName", a.ko.Spec.DomainName, b.ko.Spec.DomainName)
-	} else if a.ko.Spec.DomainName != nil && b.ko.Spec.DomainName != nil {
-		if *a.ko.Spec.DomainName != *b.ko.Spec.DomainName {
-			delta.Add("Spec.DomainName", a.ko.Spec.DomainName, b.ko.Spec.DomainName)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.EBSOptions, b.ko.Spec.EBSOptions) {
 		delta.Add("Spec.EBSOptions", a.ko.Spec.EBSOptions, b.ko.Spec.EBSOptions)
 	} else if a.ko.Spec.EBSOptions != nil && b.ko.Spec.EBSOptions != nil {
@@ -407,6 +400,13 @@ func newResourceDelta(
 			delta.Add("Spec.LogPublishingOptions", a.ko.Spec.LogPublishingOptions, b.ko.Spec.LogPublishingOptions)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+		if *a.ko.Spec.Name != *b.ko.Spec.Name {
+			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.NodeToNodeEncryptionOptions, b.ko.Spec.NodeToNodeEncryptionOptions) {
 		delta.Add("Spec.NodeToNodeEncryptionOptions", a.ko.Spec.NodeToNodeEncryptionOptions, b.ko.Spec.NodeToNodeEncryptionOptions)
 	} else if a.ko.Spec.NodeToNodeEncryptionOptions != nil && b.ko.Spec.NodeToNodeEncryptionOptions != nil {
@@ -418,8 +418,8 @@ func newResourceDelta(
 			}
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.TagList, b.ko.Spec.TagList) {
-		delta.Add("Spec.TagList", a.ko.Spec.TagList, b.ko.Spec.TagList)
+	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCOptions, b.ko.Spec.VPCOptions) {
 		delta.Add("Spec.VPCOptions", a.ko.Spec.VPCOptions, b.ko.Spec.VPCOptions)

--- a/pkg/resource/domain/resource.go
+++ b/pkg/resource/domain/resource.go
@@ -88,7 +88,7 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Spec.DomainName = &identifier.NameOrID
+	r.ko.Spec.Name = &identifier.NameOrID
 
 	return nil
 }

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -249,9 +249,9 @@ func (rm *resourceManager) sdkFind(
 		ko.Status.DomainID = nil
 	}
 	if resp.DomainStatus.DomainName != nil {
-		ko.Spec.DomainName = resp.DomainStatus.DomainName
+		ko.Spec.Name = resp.DomainStatus.DomainName
 	} else {
-		ko.Spec.DomainName = nil
+		ko.Spec.Name = nil
 	}
 	if resp.DomainStatus.EBSOptions != nil {
 		f12 := &svcapitypes.EBSOptions{}
@@ -421,7 +421,7 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadOneInput(
 	r *resource,
 ) bool {
-	return r.ko.Spec.DomainName == nil
+	return r.ko.Spec.Name == nil
 
 }
 
@@ -432,8 +432,8 @@ func (rm *resourceManager) newDescribeRequestPayload(
 ) (*svcsdk.DescribeDomainInput, error) {
 	res := &svcsdk.DescribeDomainInput{}
 
-	if r.ko.Spec.DomainName != nil {
-		res.SetDomainName(*r.ko.Spec.DomainName)
+	if r.ko.Spec.Name != nil {
+		res.SetDomainName(*r.ko.Spec.Name)
 	}
 
 	return res, nil
@@ -634,9 +634,9 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.DomainID = nil
 	}
 	if resp.DomainStatus.DomainName != nil {
-		ko.Spec.DomainName = resp.DomainStatus.DomainName
+		ko.Spec.Name = resp.DomainStatus.DomainName
 	} else {
-		ko.Spec.DomainName = nil
+		ko.Spec.Name = nil
 	}
 	if resp.DomainStatus.EBSOptions != nil {
 		f12 := &svcapitypes.EBSOptions{}
@@ -991,8 +991,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 		}
 		res.SetDomainEndpointOptions(f6)
 	}
-	if r.ko.Spec.DomainName != nil {
-		res.SetDomainName(*r.ko.Spec.DomainName)
+	if r.ko.Spec.Name != nil {
+		res.SetDomainName(*r.ko.Spec.Name)
 	}
 	if r.ko.Spec.EBSOptions != nil {
 		f8 := &svcsdk.EBSOptions{}
@@ -1044,9 +1044,9 @@ func (rm *resourceManager) newCreateRequestPayload(
 		}
 		res.SetNodeToNodeEncryptionOptions(f12)
 	}
-	if r.ko.Spec.TagList != nil {
+	if r.ko.Spec.Tags != nil {
 		f13 := []*svcsdk.Tag{}
-		for _, f13iter := range r.ko.Spec.TagList {
+		for _, f13iter := range r.ko.Spec.Tags {
 			f13elem := &svcsdk.Tag{}
 			if f13iter.Key != nil {
 				f13elem.SetKey(*f13iter.Key)
@@ -1126,8 +1126,8 @@ func (rm *resourceManager) newDeleteRequestPayload(
 ) (*svcsdk.DeleteDomainInput, error) {
 	res := &svcsdk.DeleteDomainInput{}
 
-	if r.ko.Spec.DomainName != nil {
-		res.SetDomainName(*r.ko.Spec.DomainName)
+	if r.ko.Spec.Name != nil {
+		res.SetDomainName(*r.ko.Spec.Name)
 	}
 
 	return res, nil

--- a/test/e2e/resources/domain_es7.9.yaml
+++ b/test/e2e/resources/domain_es7.9.yaml
@@ -3,7 +3,7 @@ kind: Domain
 metadata:
   name: $DOMAIN_NAME
 spec:
-  domainName: $DOMAIN_NAME
+  name: $DOMAIN_NAME
   engineVersion: "Elasticsearch_7.9"
   # EBSOptions is required for default OpenSearch domain instance type
   # m4.large.search

--- a/test/e2e/resources/domain_es_xdym_multi_az7.9.yaml
+++ b/test/e2e/resources/domain_es_xdym_multi_az7.9.yaml
@@ -3,7 +3,7 @@ kind: Domain
 metadata:
   name: $DOMAIN_NAME
 spec:
-  domainName: $DOMAIN_NAME
+  name: $DOMAIN_NAME
   engineVersion: "Elasticsearch_7.9"
   clusterConfig:
     dedicatedMasterEnabled: true

--- a/test/e2e/resources/domain_es_xdym_multi_az_vpc7.9.yaml
+++ b/test/e2e/resources/domain_es_xdym_multi_az_vpc7.9.yaml
@@ -3,7 +3,7 @@ kind: Domain
 metadata:
   name: $DOMAIN_NAME
 spec:
-  domainName: $DOMAIN_NAME
+  name: $DOMAIN_NAME
   engineVersion: "Elasticsearch_7.9"
   clusterConfig:
     dedicatedMasterEnabled: true


### PR DESCRIPTION
Renames Domain.DomainName to Domain.Name and Domain.TagList to
Domain.Tags to align the opensearchservice controller with other ACK
controllers and CRDs.

NOTE: This is a backwards-incompatible API change but I figure this
would be better to do early on in preview now than later...

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
