### PR TITLE
ACK runtime upgrade v0.16.0 => v0.16.1 

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-01-07T20:33:27Z"
-  build_hash: 3e184727de8a4dfd4769e3d88f4f52f885858335
+  build_date: "2022-01-14T12:33:43Z"
+  build_hash: 3e0ecb910d3296a0f9580891a9af846ac1bf3bac
   go_version: go1.17.5
-  version: v0.16.0
+  version: v0.16.1
 api_directory_checksum: 6f3ca5de4e5a1ac8cb5366ab502f7c73c8d5c88f
 api_version: v1alpha1
 aws_sdk_go_version: v1.40.51

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -57,7 +57,6 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           runAsNonRoot: true
-          runAsUser: 1000
           capabilities:
             drop:
               - ALL

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/opensearchservice-controller
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.16.0
+	github.com/aws-controllers-k8s/runtime v0.16.1
 	github.com/aws/aws-sdk-go v1.40.51
 	github.com/go-logr/logr v1.2.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.16.0 h1:X2uwgp8qW2aVwM7kCXyq/7sZzWDSbkRqIOVO0FgGGYs=
-github.com/aws-controllers-k8s/runtime v0.16.0/go.mod h1:DHwPczqO/nK4L1kqWlmng5GuIQuX5MSSWbTQMuL4LnM=
+github.com/aws-controllers-k8s/runtime v0.16.1 h1:up+vn3J8mqjaHgleOSCU7wGqj7t8RCvF+V4EhdMEtSY=
+github.com/aws-controllers-k8s/runtime v0.16.1/go.mod h1:DHwPczqO/nK4L1kqWlmng5GuIQuX5MSSWbTQMuL4LnM=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.51 h1:FfxDcjWqhMGwy+raf5Zf6AH8qsHIl9YG2dvJIBx1Aw4=
 github.com/aws/aws-sdk-go v1.40.51/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: opensearchservice-chart
 description: A Helm chart for the ACK service controller for Amazon OpenSearch Service (OpenSearch)
-version: v0.0.4
-appVersion: v0.0.4
+version: v0.0.5
+appVersion: v0.0.5
 home: https://github.com/aws-controllers-k8s/opensearchservice-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -77,7 +77,6 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           runAsNonRoot: true
-          runAsUser: 1000
           capabilities:
             drop:
               - ALL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/opensearchservice-controller
-  tag: v0.0.4
+  tag: v0.0.5
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -820,7 +820,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetAdvancedOptions(f1)
 	}
 	if r.ko.Spec.AdvancedSecurityOptions != nil {
-		f2 := &svcsdk.AdvancedSecurityOptionsInput_{}
+		f2 := &svcsdk.AdvancedSecurityOptionsInput{}
 		if r.ko.Spec.AdvancedSecurityOptions.Enabled != nil {
 			f2.SetEnabled(*r.ko.Spec.AdvancedSecurityOptions.Enabled)
 		}
@@ -847,7 +847,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 			f2.SetMasterUserOptions(f2f2)
 		}
 		if r.ko.Spec.AdvancedSecurityOptions.SAMLOptions != nil {
-			f2f3 := &svcsdk.SAMLOptionsInput_{}
+			f2f3 := &svcsdk.SAMLOptionsInput{}
 			if r.ko.Spec.AdvancedSecurityOptions.SAMLOptions.Enabled != nil {
 				f2f3.SetEnabled(*r.ko.Spec.AdvancedSecurityOptions.SAMLOptions.Enabled)
 			}
@@ -881,7 +881,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetAdvancedSecurityOptions(f2)
 	}
 	if r.ko.Spec.AutoTuneOptions != nil {
-		f3 := &svcsdk.AutoTuneOptionsInput_{}
+		f3 := &svcsdk.AutoTuneOptionsInput{}
 		if r.ko.Spec.AutoTuneOptions.DesiredState != nil {
 			f3.SetDesiredState(*r.ko.Spec.AutoTuneOptions.DesiredState)
 		}

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -820,7 +820,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetAdvancedOptions(f1)
 	}
 	if r.ko.Spec.AdvancedSecurityOptions != nil {
-		f2 := &svcsdk.AdvancedSecurityOptionsInput{}
+		f2 := &svcsdk.AdvancedSecurityOptionsInput_{}
 		if r.ko.Spec.AdvancedSecurityOptions.Enabled != nil {
 			f2.SetEnabled(*r.ko.Spec.AdvancedSecurityOptions.Enabled)
 		}
@@ -847,7 +847,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 			f2.SetMasterUserOptions(f2f2)
 		}
 		if r.ko.Spec.AdvancedSecurityOptions.SAMLOptions != nil {
-			f2f3 := &svcsdk.SAMLOptionsInput{}
+			f2f3 := &svcsdk.SAMLOptionsInput_{}
 			if r.ko.Spec.AdvancedSecurityOptions.SAMLOptions.Enabled != nil {
 				f2f3.SetEnabled(*r.ko.Spec.AdvancedSecurityOptions.SAMLOptions.Enabled)
 			}
@@ -881,7 +881,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetAdvancedSecurityOptions(f2)
 	}
 	if r.ko.Spec.AutoTuneOptions != nil {
-		f3 := &svcsdk.AutoTuneOptionsInput{}
+		f3 := &svcsdk.AutoTuneOptionsInput_{}
 		if r.ko.Spec.AutoTuneOptions.DesiredState != nil {
 			f3.SetDesiredState(*r.ko.Spec.AutoTuneOptions.DesiredState)
 		}


### PR DESCRIPTION
Description of changes:
* ACK runtime update to v0.16.1
* Manually adding "_" to field names after code generation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
