### PR TITLE
feat: set AutoTuneOptions during READ_ONE

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2025-08-15T00:13:00Z"
-  build_hash: b6df33f8c7f55b234555c0b578b8de43c74771a8
-  go_version: go1.24.6
-  version: v0.51.0
-api_directory_checksum: d8782f0b55fdcfa7bc2169adce79f2425c6906b6
+  build_date: "2025-08-26T17:41:46Z"
+  build_hash: 1045a5e99038b11b0630ca2f2f69c3bae4bedba6
+  go_version: go1.24.5
+  version: v0.51.0-1-g1045a5e
+api_directory_checksum: 830e0ee1ec43d7bec4fdedd169cd8f4d4bcad5e7
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-08-26T17:41:46Z"
-  build_hash: 1045a5e99038b11b0630ca2f2f69c3bae4bedba6
+  build_date: "2025-09-18T00:31:11Z"
+  build_hash: 1d9076d0211773ff8ab8682b28b912c7ece10676
   go_version: go1.24.5
-  version: v0.51.0-1-g1045a5e
-api_directory_checksum: 830e0ee1ec43d7bec4fdedd169cd8f4d4bcad5e7
+  version: v0.51.0-2-g1d9076d
+api_directory_checksum: d8782f0b55fdcfa7bc2169adce79f2425c6906b6
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 0a215c23a6cf672a79864eba904f2497bdd8802b
+  file_checksum: a4b95a484efab35722da9fe960e680e521f18321
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -48,8 +48,13 @@ resources:
         template_path: hooks/domain/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/domain/sdk_delete_pre_build_request.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
     fields:
       AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword:
         is_secret: true
+      AutoTuneOptions.MaintenanceSchedules:
+        compare:
+          is_ignored: true
     update_operation:
       custom_method_name: customUpdateDomain

--- a/generator.yaml
+++ b/generator.yaml
@@ -48,8 +48,13 @@ resources:
         template_path: hooks/domain/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/domain/sdk_delete_pre_build_request.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
     fields:
       AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword:
         is_secret: true
+      AutoTuneOptions.MaintenanceSchedules:
+        compare:
+          is_ignored: true
     update_operation:
       custom_method_name: customUpdateDomain

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.7.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/itchyny/gojq v0.12.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvR
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/resource/domain/delta.go
+++ b/pkg/resource/domain/delta.go
@@ -42,6 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AIMLOptions, b.ko.Spec.AIMLOptions) {
 		delta.Add("Spec.AIMLOptions", a.ko.Spec.AIMLOptions, b.ko.Spec.AIMLOptions)
@@ -226,13 +227,6 @@ func newResourceDelta(
 		} else if a.ko.Spec.AutoTuneOptions.DesiredState != nil && b.ko.Spec.AutoTuneOptions.DesiredState != nil {
 			if *a.ko.Spec.AutoTuneOptions.DesiredState != *b.ko.Spec.AutoTuneOptions.DesiredState {
 				delta.Add("Spec.AutoTuneOptions.DesiredState", a.ko.Spec.AutoTuneOptions.DesiredState, b.ko.Spec.AutoTuneOptions.DesiredState)
-			}
-		}
-		if len(a.ko.Spec.AutoTuneOptions.MaintenanceSchedules) != len(b.ko.Spec.AutoTuneOptions.MaintenanceSchedules) {
-			delta.Add("Spec.AutoTuneOptions.MaintenanceSchedules", a.ko.Spec.AutoTuneOptions.MaintenanceSchedules, b.ko.Spec.AutoTuneOptions.MaintenanceSchedules)
-		} else if len(a.ko.Spec.AutoTuneOptions.MaintenanceSchedules) > 0 {
-			if !reflect.DeepEqual(a.ko.Spec.AutoTuneOptions.MaintenanceSchedules, b.ko.Spec.AutoTuneOptions.MaintenanceSchedules) {
-				delta.Add("Spec.AutoTuneOptions.MaintenanceSchedules", a.ko.Spec.AutoTuneOptions.MaintenanceSchedules, b.ko.Spec.AutoTuneOptions.MaintenanceSchedules)
 			}
 		}
 		if ackcompare.HasNilDifference(a.ko.Spec.AutoTuneOptions.UseOffPeakWindow, b.ko.Spec.AutoTuneOptions.UseOffPeakWindow) {

--- a/pkg/resource/domain/resource.go
+++ b/pkg/resource/domain/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	f0, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
+	r.ko.Spec.Name = &f0
 
 	return nil
 }

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -535,6 +535,10 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	err = rm.setAutoTuneOptions(ctx, ko)
+	if err != nil {
+		return &resource{ko}, err
+	}
 	checkDomainStatus(resp, ko)
 
 	return &resource{ko}, nil

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -1040,6 +1040,10 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	err = rm.setAutoTuneOptions(ctx, ko)
+	if err != nil {
+		return &resource{ko}, err
+	}
 	if domainProcessing(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.

--- a/templates/hooks/domain/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/domain/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,7 @@
+	err = rm.setAutoTuneOptions(ctx, ko)
+	if err != nil {
+		return &resource{ko}, err
+	}
 	if domainProcessing(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.

--- a/templates/hooks/domain/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/domain/sdk_read_one_post_set_output.go.tpl
@@ -1,1 +1,5 @@
+	err = rm.setAutoTuneOptions(ctx, ko)
+	if err != nil {
+		return &resource{ko}, err
+	}
 	checkDomainStatus(resp, ko)

--- a/test/e2e/domain.py
+++ b/test/e2e/domain.py
@@ -126,6 +126,19 @@ def get(domain_name):
     except c.exceptions.ResourceNotFoundException:
         return None
 
+def get_config(domain_name):
+    """Returns a dict containing the domain config from the OpenSearch API.
+
+    if no such domain exists, returns None.
+    """
+    c = boto3.client('opensearch')
+    try:
+        resp = c.describe_domain_config(DomainName=domain_name)
+        assert 'DomainConfig' in resp
+        return resp
+    except c.exceptions.ResourceNotFoundException:
+        return None
+    
 
 # Apparently, there is an 'endpoint' and an 'endpoints' field for a domain.
 # The 'endpoint' field is filled in with a URL when the domain does *not* use

--- a/test/e2e/resources/domain_es7.9.yaml
+++ b/test/e2e/resources/domain_es7.9.yaml
@@ -20,6 +20,12 @@ spec:
     enabled: true
   nodeToNodeEncryptionOptions:
     enabled: true
+  autoTuneOptions:
+    maintenanceSchedules:
+    - startAt: 2025-12-15T00:00:00Z
+      duration:
+        unit: HOURS
+        value: 2
   advancedSecurityOptions:
     enabled: true
     internalUserDatabaseEnabled: true


### PR DESCRIPTION
Issue [#2590](https://github.com/aws-controllers-k8s/community/issues/2590)

Description of changes:

Currently, the api we used to describe a domain resource did not return
the AutoTuneOption config, with all its values populated (maintenance
schedule, desiredState, etc.).
Without the latest state of AutoTuneOptions, updates were not

With this change, we will be adding an API call to retrieve the latest
AutoTuneOptions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
