### PR TITLE
chore: remove Domain custom resync period

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-03-11T22:05:42Z"
-  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.7
-  version: v0.58.0
+  build_date: "2026-04-21T22:42:02Z"
+  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  go_version: go1.26.0
+  version: v0.58.0-6-gc55e822
 api_directory_checksum: d8782f0b55fdcfa7bc2169adce79f2425c6906b6
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: a4b95a484efab35722da9fe960e680e521f18321
+  file_checksum: 387998005e640464fc0e7969070347881b9fc150
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -28,11 +28,10 @@ resources:
         DescribeDomain:
           input_fields:
             DomainName: Name
-    reconcile:
-      # Doing this because it takes a LONG time for the Domain's
-      # endpoint/endpoints field to be populated, even after the Domain's
-      # Processing field is set to False after creation...
-      requeue_on_success_seconds: 60
+    synced:
+      when:
+      - path: Status.DomainProcessingStatus
+        in: [ "Active", "Isolated" ]
     exceptions:
       errors:
         404:

--- a/generator.yaml
+++ b/generator.yaml
@@ -28,11 +28,10 @@ resources:
         DescribeDomain:
           input_fields:
             DomainName: Name
-    reconcile:
-      # Doing this because it takes a LONG time for the Domain's
-      # endpoint/endpoints field to be populated, even after the Domain's
-      # Processing field is set to False after creation...
-      requeue_on_success_seconds: 60
+    synced:
+      when:
+      - path: Status.DomainProcessingStatus
+        in: [ "Active", "Isolated" ]
     exceptions:
       errors:
         404:

--- a/pkg/resource/domain/hooks.go
+++ b/pkg/resource/domain/hooks.go
@@ -72,8 +72,6 @@ func checkDomainStatus(resp *svcsdk.DescribeDomainOutput, ko *svcapitypes.Domain
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-	} else {
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
 }
 
@@ -149,22 +147,19 @@ func (rm *resourceManager) customUpdateDomain(ctx context.Context, desired, late
 	updated = &resource{res}
 	updated.SetStatus(latest)
 
+	isSynced, err := rm.IsSynced(ctx, latest)
+	if err != nil {
+		return updated, err
+	}
+	if !isSynced {
+		return updated, ackrequeue.Needed(fmt.Errorf("requeueing update, domain is not synced"))
+	}
+
 	if latest.ko.Spec.AutoTuneOptions != nil &&
 		latest.ko.Spec.AutoTuneOptions.DesiredState != nil {
 		if ready, _ := isAutoTuneOptionReady(*latest.ko.Spec.AutoTuneOptions.DesiredState, nil); !ready {
 			return updated, ackrequeue.Needed(fmt.Errorf("autoTuneOption is updating"))
 		}
-	}
-
-	if domainProcessing(latest) {
-		msg := "Domain is currently processing configuration changes"
-		ackcondition.SetSynced(desired, corev1.ConditionFalse, &msg, nil)
-		return updated, requeueWaitWhileProcessing
-	}
-	if latest.ko.Status.UpgradeProcessing != nil && *latest.ko.Status.UpgradeProcessing {
-		msg := "Domain is currently upgrading software"
-		ackcondition.SetSynced(desired, corev1.ConditionFalse, &msg, nil)
-		return updated, requeueWaitWhileProcessing
 	}
 
 	if desired.ko.Spec.EngineVersion != nil && delta.DifferentAt("Spec.EngineVersion") {

--- a/pkg/resource/domain/manager.go
+++ b/pkg/resource/domain/manager.go
@@ -268,6 +268,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.DomainProcessingStatus == nil {
+		return false, nil
+	}
+	domainProcessingStatusCandidates := []string{"Active", "Isolated"}
+	if !ackutil.InStrings(*r.ko.Status.DomainProcessingStatus, domainProcessingStatusCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/domain/manager_factory.go
+++ b/pkg/resource/domain/manager_factory.go
@@ -86,7 +86,7 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 // RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
 // Default is false which means resource will not be requeued after success.
 func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
-	return 60
+	return 0
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/pkg/resource/domain/sdk.go
+++ b/pkg/resource/domain/sdk.go
@@ -1573,13 +1573,8 @@ func (rm *resourceManager) updateConditions(
 			recoverableCondition.Message = nil
 		}
 	}
-	if syncCondition == nil && onSuccess {
-		syncCondition = &ackv1alpha1.Condition{
-			Type:   ackv1alpha1.ConditionTypeResourceSynced,
-			Status: corev1.ConditionTrue,
-		}
-		ko.Status.Conditions = append(ko.Status.Conditions, syncCondition)
-	}
+	// Required to avoid the "declared but not used" error in the default case
+	_ = syncCondition
 	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
 		return &resource{ko}, true // updated
 	}

--- a/test/e2e/tests/test_domain.py
+++ b/test/e2e/tests/test_domain.py
@@ -45,9 +45,9 @@ CHECK_STATUS_WAIT_SECONDS = 60
 
 # It can take a LONG time for the domain's endpoint/endpoints field to be
 # returned, even after Processing=False and the ResourceSynced condition is set
-# to True on a domain. Domain resources are requeued on success which means the
-# controller will poll for latest status, including endpoint/endpoints, every
-# 30 seconds, so 2 minutes *should* be enough here.
+# to True on a domain. The controller requeues while the domain's
+# DomainProcessingStatus is not Active/Isolated, so 2 minutes *should* be
+# enough here after the domain reaches a synced state.
 CHECK_ENDPOINT_WAIT_SECONDS = 60*2
 
 
@@ -247,9 +247,9 @@ class TestDomain:
 
         cr = k8s.get_resource(ref)
         assert cr is not None
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=30)
         assert 'status' in cr
         domain.assert_endpoint(cr)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=30)
 
         # now we will modify the engine version to test upgrades
         # similar to creating a new domain, this takes a long time, often 20+ minutes
@@ -280,18 +280,16 @@ class TestDomain:
 
         # wait for 15 minutes, it's always going to take at least this long
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        # now loop to see if it's done, with a max elapsed time so the test doesn't run forever
-        count = 0
-        while count < 30:
-            count += 1
-            latest = domain.get(resource.name)
-            assert latest is not None
-            if latest['DomainStatus']['UpgradeProcessing'] is True:
-                time.sleep(CHECK_STATUS_WAIT_SECONDS)
-                continue
-            else:
-                break
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        # wait for DomainProcessing to be False
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=30)
+        latest = domain.get(resource.name)
+        assert latest['DomainStatus']['UpgradeProcessing'] == False
+
+        # wait for SoftwareUpdateOptions to be updated
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=1)
+        latest = domain.get(resource.name)
         cr = k8s.get_resource(ref)
 
         assert latest['DomainStatus']['SoftwareUpdateOptions']["AutoSoftwareUpdateEnabled"] is True
@@ -338,6 +336,7 @@ class TestDomain:
 
         cr = k8s.get_resource(ref)
         assert cr is not None
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=30)
         assert 'status' in cr
         domain.assert_endpoint(cr)
 
@@ -358,6 +357,7 @@ class TestDomain:
 
         cr = k8s.get_resource(ref)
         assert cr is not None
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=30)
         assert 'status' in cr
         domain.assert_endpoints(cr)
         


### PR DESCRIPTION
Issue [#2218](https://github.com/aws-controllers-k8s/community/issues/2218)

Description of changes:
The Domain resource had a hard coded 1 minute resync period. This period
caused a lot of throttling errors. With this change, we will remove the 
`generator.yaml` resync period, and default to using the global resync 
period (10h by default)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
