### PR TITLE
fix: ignore AdvancedSecurityOptions.MasterUserOptions from comparisons and use IAM policy comparator for accesspolicies

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:24:58Z"
+  build_date: "2026-04-23T00:41:48Z"
   build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
   go_version: go1.26.2
   version: v0.58.1
@@ -7,7 +7,7 @@ api_directory_checksum: d8782f0b55fdcfa7bc2169adce79f2425c6906b6
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 387998005e640464fc0e7969070347881b9fc150
+  file_checksum: 03bd7346ebe96a7f8d9164d6b7442ebf862dcce5
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-04-23T00:41:48Z"
+  build_date: "2026-04-24T06:19:50Z"
   build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
   go_version: go1.26.2
   version: v0.58.1
@@ -7,7 +7,7 @@ api_directory_checksum: d8782f0b55fdcfa7bc2169adce79f2425c6906b6
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 03bd7346ebe96a7f8d9164d6b7442ebf862dcce5
+  file_checksum: 7dbb82d883af252564f012ca93309cc70d63089b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -50,6 +50,11 @@ resources:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
     fields:
+      # DescribeDomain does not return masterUserOptions in the response
+      # To prevent a perpetual diff, ignore the fields from comparison
+      AdvancedSecurityOptions.MasterUserOptions:
+        compare:
+          is_ignored: true
       AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword:
         is_secret: true
       AutoTuneOptions.MaintenanceSchedules:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -60,5 +60,7 @@ resources:
       AutoTuneOptions.MaintenanceSchedules:
         compare:
           is_ignored: true
+      AccessPolicies:
+        is_iam_policy: true
     update_operation:
       custom_method_name: customUpdateDomain

--- a/generator.yaml
+++ b/generator.yaml
@@ -50,6 +50,11 @@ resources:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
     fields:
+      # DescribeDomain does not return masterUserOptions in the response
+      # To prevent a perpetual diff, ignore the fields from comparison
+      AdvancedSecurityOptions.MasterUserOptions:
+        compare:
+          is_ignored: true
       AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword:
         is_secret: true
       AutoTuneOptions.MaintenanceSchedules:

--- a/generator.yaml
+++ b/generator.yaml
@@ -60,5 +60,7 @@ resources:
       AutoTuneOptions.MaintenanceSchedules:
         compare:
           is_ignored: true
+      AccessPolicies:
+        is_iam_policy: true
     update_operation:
       custom_method_name: customUpdateDomain

--- a/pkg/resource/domain/delta.go
+++ b/pkg/resource/domain/delta.go
@@ -128,31 +128,6 @@ func newResourceDelta(
 				}
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions) {
-			delta.Add("Spec.AdvancedSecurityOptions.MasterUserOptions", a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions)
-		} else if a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions != nil && b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions != nil {
-			if ackcompare.HasNilDifference(a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN) {
-				delta.Add("Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN", a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN)
-			} else if a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN != nil && b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN != nil {
-				if *a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN != *b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN {
-					delta.Add("Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN", a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserARN)
-				}
-			}
-			if ackcompare.HasNilDifference(a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName) {
-				delta.Add("Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName", a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName)
-			} else if a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName != nil && b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName != nil {
-				if *a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName != *b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName {
-					delta.Add("Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName", a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserName)
-				}
-			}
-			if ackcompare.HasNilDifference(a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword) {
-				delta.Add("Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword", a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword)
-			} else if a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword != nil && b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword != nil {
-				if *a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword != *b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword {
-					delta.Add("Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword", a.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword, b.ko.Spec.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword)
-				}
-			}
-		}
 		if ackcompare.HasNilDifference(a.ko.Spec.AdvancedSecurityOptions.SAMLOptions, b.ko.Spec.AdvancedSecurityOptions.SAMLOptions) {
 			delta.Add("Spec.AdvancedSecurityOptions.SAMLOptions", a.ko.Spec.AdvancedSecurityOptions.SAMLOptions, b.ko.Spec.AdvancedSecurityOptions.SAMLOptions)
 		} else if a.ko.Spec.AdvancedSecurityOptions.SAMLOptions != nil && b.ko.Spec.AdvancedSecurityOptions.SAMLOptions != nil {

--- a/pkg/resource/domain/delta.go
+++ b/pkg/resource/domain/delta.go
@@ -61,7 +61,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.AccessPolicies, b.ko.Spec.AccessPolicies) {
 		delta.Add("Spec.AccessPolicies", a.ko.Spec.AccessPolicies, b.ko.Spec.AccessPolicies)
 	} else if a.ko.Spec.AccessPolicies != nil && b.ko.Spec.AccessPolicies != nil {
-		if *a.ko.Spec.AccessPolicies != *b.ko.Spec.AccessPolicies {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.AccessPolicies, *b.ko.Spec.AccessPolicies); err != nil || !equal {
 			delta.Add("Spec.AccessPolicies", a.ko.Spec.AccessPolicies, b.ko.Spec.AccessPolicies)
 		}
 	}


### PR DESCRIPTION
Issue #, if available:

Description of changes: DescribeDomain does not return the AdvancedSecurityOptions.MasterUserOptions in the response which causes a perpetual diff on the resource

https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_DescribeDomain.html#API_DescribeDomain_ResponseElements

Additionally, use IAM policy comparator for accesspolicies to ensure any changes that don't affect the policy
spec are ignored. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
